### PR TITLE
Changed to always have kubectl- prefix

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,13 +3,13 @@
 # SPDX-License-Identifier: CC0-1.0
 
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
-project_name: klock
+project_name: kubectl-klock
 release:
   github:
     owner: jilleJr
     name: kubectl-klock
 builds:
-  - id: klock
+  - id: kubectl-klock
     goos:
     - linux
     - windows
@@ -24,9 +24,9 @@ builds:
     main: main.go
     ldflags: -s -w -X main.version={{ .Version }}
 archives:
-  - id: klock
+  - id: kubectl-klock
     builds:
-    - klock
+    - kubectl-klock
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
     format_overrides:
     - goos: windows

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -14,97 +14,97 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-    {{addURIAndSha "https://github.com/jilleJr/kubectl-klock/releases/download/{{ .TagName }}/klock_linux_amd64.tar.gz" .TagName }}
+    {{addURIAndSha "https://github.com/jilleJr/kubectl-klock/releases/download/{{ .TagName }}/kubectl-klock_linux_amd64.tar.gz" .TagName }}
     files:
-    - from: "./klock"
+    - from: "./kubectl-klock"
       to: "."
     - from: LICENSE
       to: "."
-    bin: "klock"
+    bin: "kubectl-klock"
 
   - selector:
       matchLabels:
         os: linux
         arch: "386"
-    {{addURIAndSha "https://github.com/jilleJr/kubectl-klock/releases/download/{{ .TagName }}/klock_linux_386.tar.gz" .TagName }}
+    {{addURIAndSha "https://github.com/jilleJr/kubectl-klock/releases/download/{{ .TagName }}/kubectl-klock_linux_386.tar.gz" .TagName }}
     files:
-    - from: "./klock"
+    - from: "./kubectl-klock"
       to: "."
     - from: LICENSE
       to: "."
-    bin: "klock"
+    bin: "kubectl-klock"
 
   - selector:
       matchLabels:
         os: linux
         arch: "arm64"
-    {{addURIAndSha "https://github.com/jilleJr/kubectl-klock/releases/download/{{ .TagName }}/klock_linux_arm64.tar.gz" .TagName }}
+    {{addURIAndSha "https://github.com/jilleJr/kubectl-klock/releases/download/{{ .TagName }}/kubectl-klock_linux_arm64.tar.gz" .TagName }}
     files:
-    - from: "./klock"
+    - from: "./kubectl-klock"
       to: "."
     - from: LICENSE
       to: "."
-    bin: "klock"
+    bin: "kubectl-klock"
 
   - selector:
       matchLabels:
         os: darwin
         arch: amd64
-    {{addURIAndSha "https://github.com/jilleJr/kubectl-klock/releases/download/{{ .TagName }}/klock_darwin_amd64.tar.gz" .TagName }}
+    {{addURIAndSha "https://github.com/jilleJr/kubectl-klock/releases/download/{{ .TagName }}/kubectl-klock_darwin_amd64.tar.gz" .TagName }}
     files:
-    - from: "./klock"
+    - from: "./kubectl-klock"
       to: "."
     - from: LICENSE
       to: "."
-    bin: "klock"
+    bin: "kubectl-klock"
 
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    {{addURIAndSha "https://github.com/jilleJr/kubectl-klock/releases/download/{{ .TagName }}/klock_darwin_arm64.tar.gz" .TagName }}
+    {{addURIAndSha "https://github.com/jilleJr/kubectl-klock/releases/download/{{ .TagName }}/kubectl-klock_darwin_arm64.tar.gz" .TagName }}
     files:
-    - from: "./klock"
+    - from: "./kubectl-klock"
       to: "."
     - from: LICENSE
       to: "."
-    bin: "klock"
+    bin: "kubectl-klock"
 
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    {{addURIAndSha "https://github.com/jilleJr/kubectl-klock/releases/download/{{ .TagName }}/klock_windows_amd64.zip" .TagName }}
+    {{addURIAndSha "https://github.com/jilleJr/kubectl-klock/releases/download/{{ .TagName }}/kubectl-klock_windows_amd64.zip" .TagName }}
     files:
-    - from: "/klock.exe"
+    - from: "/kubectl-klock.exe"
       to: "."
     - from: LICENSE
       to: "."
-    bin: "klock.exe"
+    bin: "kubectl-klock.exe"
 
   - selector:
       matchLabels:
         os: windows
         arch: "386"
-    {{addURIAndSha "https://github.com/jilleJr/kubectl-klock/releases/download/{{ .TagName }}/klock_windows_386.zip" .TagName }}
+    {{addURIAndSha "https://github.com/jilleJr/kubectl-klock/releases/download/{{ .TagName }}/kubectl-klock_windows_386.zip" .TagName }}
     files:
-    - from: "/klock.exe"
+    - from: "/kubectl-klock.exe"
       to: "."
     - from: LICENSE
       to: "."
-    bin: "klock.exe"
+    bin: "kubectl-klock.exe"
 
   - selector:
       matchLabels:
         os: windows
         arch: arm64
-    {{addURIAndSha "https://github.com/jilleJr/kubectl-klock/releases/download/{{ .TagName }}/klock_windows_arm64.zip" .TagName }}
+    {{addURIAndSha "https://github.com/jilleJr/kubectl-klock/releases/download/{{ .TagName }}/kubectl-klock_windows_arm64.zip" .TagName }}
     files:
-    - from: "/klock.exe"
+    - from: "/kubectl-klock.exe"
       to: "."
     - from: LICENSE
       to: "."
-    bin: "klock.exe"
+    bin: "kubectl-klock.exe"
 
   shortDescription: Watches resources
   description: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 ## v0.5.0 (WIP)
 
+- BREAKING: Changed binary name from `klock` to `kubectl-klock`.
+  Any automated tooling downloading from GitHub release assets may break. (#41)
+
 - Added `completion` subcommand. (#34)
 
 - Added completion to resource type and name. (#34)

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@
 # SPDX-License-Identifier: CC0-1.0
 
 ifeq ($(OS),Windows_NT)
-BINARY := klock.exe
+BINARY := kubectl-klock.exe
 else
-BINARY := klock
+BINARY := kubectl-klock
 endif
 
 GO_FILES=$(shell git ls-files '*.go')

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Requires Krew: <https://krew.sigs.k8s.io/>
 
 ```sh
 kubectl krew install klock
-kubectl klock pods
 ```
 
 ### Nix
@@ -42,23 +41,15 @@ nix-shell -p kubectl-klock
 
 ### Pre-built binaries
 
-You can download prebuilt binaries from the latest GitHub release: <https://github.com/jilleJr/kubectl-klock/releases/latest>
+You can download pre-built binaries from the latest GitHub release: <https://github.com/jilleJr/kubectl-klock/releases/latest>
 
 Download the one that fits your OS and architecture, extract the
-tarball/zip file, and move the `klock` binary to somewhere in your PATH.
+tarball/zip file, and move the `kubectl-klock` binary to somewhere in your PATH.
 For example:
 
 ```sh
-tar -xzf klock_linux_amd64.tar.gz
-sudo mv ./klock /usr/local/bin
-klock pods
-```
-
-For it to work as a subcommand to `kubectl`, rename it to `kubectl-klock`.
-
-```sh
-sudo mv /usr/local/bin/klock /usr/local/bin/kubectl-klock
-kubectl klock pods
+tar -xzf kubectl-klock_linux_amd64.tar.gz
+sudo mv ./kubectl-klock /usr/local/bin
 ```
 
 ### From source


### PR DESCRIPTION
Got annoying to keep track of when to use `klock` and when to use `kubectl-klock`.

This plugin isn't really intended to be run as standalone anyway
