### PR TITLE
Parse restart column `5 (3m ago)`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2019 Replicated, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: test
+on:
+  pull_request:
+    branches: [main]
+jobs:
+  go-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+
+      - name: Run tests
+        run: |
+          go test -v ./...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Added parsing of a pod's "RESTART" column (e.g `5 (3m ago)`)
   so it auto updates, similarly to the "AGE" column. (#56)
 
+- Added timer on pod's "STATUS" column when a pod is deleted
+  (e.g `Deleted (3m ago)`). (#56)
+
 ## v0.4.0 (2023-09-03)
 
 - Added text filtering. (#32, thanks @semihbkgr!)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 - Added Snap: `sudo snap install klock --edge` (#43)
 
+- Added parsing of a pod's "RESTART" column (e.g `5 (3m ago)`)
+  so it auto updates, similarly to the "AGE" column. (#56)
+
 ## v0.4.0 (2023-09-03)
 
 - Added text filtering. (#32, thanks @semihbkgr!)

--- a/pkg/klock/klock.go
+++ b/pkg/klock/klock.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/resource"
@@ -89,7 +90,7 @@ func Execute(o Options, args []string) error {
 		WideOutput: o.Output == "wide",
 	}
 	p := tea.NewProgram(t)
-	w := NewWatcher(o, p, printer, o.AllNamespaces, args)
+	w := NewWatcher(o, p, printer, args)
 	t.StartSpinner()
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -131,15 +132,14 @@ func Execute(o Options, args []string) error {
 	return err
 }
 
-func NewWatcher(options Options, program *tea.Program, printer Printer, printNamespace bool, args []string) *Watcher {
+func NewWatcher(options Options, program *tea.Program, printer Printer, args []string) *Watcher {
 	return &Watcher{
 		Options: options,
 		Program: program,
 		Printer: printer,
 		Args:    args,
 
-		printNamespace: printNamespace,
-		errorChan:      make(chan error, 3),
+		errorChan: make(chan error, 3),
 	}
 }
 
@@ -149,9 +149,8 @@ type Watcher struct {
 	Printer Printer
 	Args    []string
 
-	printNamespace bool
-	cancel         func()
-	errorChan      chan error
+	cancel    func()
+	errorChan chan error
 }
 
 func (w *Watcher) ErrorChan() <-chan error {
@@ -224,10 +223,12 @@ func (w *Watcher) startWatch(ctx context.Context, clearBeforePrinting bool) erro
 	obj := info.Object
 	mapping := info.Mapping
 
+	printNamespace := w.Options.AllNamespaces
 	if mapping != nil && mapping.Scope.Name() == meta.RESTScopeNameRoot {
 		// Resource isn't namespaced
-		w.printNamespace = false
+		printNamespace = false
 	}
+	w.Printer.Configure(mapping.GroupVersionKind, printNamespace)
 
 	// watching from resourceVersion 0, starts the watch at ~now and
 	// will return an initial watch event.  Starting form ~now, rather
@@ -253,7 +254,7 @@ func (w *Watcher) startWatch(ctx context.Context, clearBeforePrinting bool) erro
 	}
 
 	for _, objToPrint := range objsToPrint {
-		if _, err := w.Printer.PrintObj(objToPrint, w.printNamespace, watch.Added); err != nil {
+		if _, err := w.Printer.PrintObj(objToPrint, watch.Added); err != nil {
 			return err
 		}
 	}
@@ -296,7 +297,7 @@ func (w *Watcher) pipeEvents(ctx context.Context, r *resource.Result, resVersion
 			if !ok {
 				return fmt.Errorf("watch channel closed")
 			}
-			cmd, err := w.Printer.PrintObj(event.Object, w.printNamespace, event.Type)
+			cmd, err := w.Printer.PrintObj(event.Object, event.Type)
 			if err != nil {
 				return err
 			}
@@ -309,34 +310,45 @@ type Printer struct {
 	Table      *table.Model
 	WideOutput bool
 	colDefs    []metav1.TableColumnDefinition
+
+	info           schema.GroupVersionKind
+	apiVersion     string
+	kind           string
+	printNamespace bool
+}
+
+func (p *Printer) Configure(info schema.GroupVersionKind, printNamespace bool) {
+	p.info = info
+	p.apiVersion, p.kind = info.ToAPIVersionAndKind()
+	p.printNamespace = printNamespace
 }
 
 func (p *Printer) Clear() {
 	p.Table.SetRows(nil)
 }
 
-func (p *Printer) PrintObj(obj runtime.Object, printNamespace bool, eventType watch.EventType) (tea.Cmd, error) {
+func (p *Printer) PrintObj(obj runtime.Object, eventType watch.EventType) (tea.Cmd, error) {
 	objTable, err := decodeIntoTable(obj)
 	if err != nil {
 		return nil, err
 	}
-	p.updateColDefHeaders(objTable, printNamespace)
-	return p.addObjectToTable(objTable, printNamespace, eventType)
+	p.updateColDefHeaders(objTable)
+	return p.addObjectToTable(objTable, eventType)
 }
 
-func (p *Printer) updateColDefHeaders(objTable *metav1.Table, printNamespace bool) {
+func (p *Printer) updateColDefHeaders(objTable *metav1.Table) {
 	if len(objTable.ColumnDefinitions) == 0 {
 		return
 	}
 
 	numColumns := len(objTable.ColumnDefinitions)
-	if printNamespace {
+	if p.printNamespace {
 		numColumns++
 	}
 
 	headers := make([]string, 0, numColumns)
 
-	if printNamespace {
+	if p.printNamespace {
 		headers = append(headers, "NAMESPACE")
 	}
 	for _, colDef := range objTable.ColumnDefinitions {
@@ -348,7 +360,7 @@ func (p *Printer) updateColDefHeaders(objTable *metav1.Table, printNamespace boo
 	p.colDefs = objTable.ColumnDefinitions
 }
 
-func (p *Printer) addObjectToTable(objTable *metav1.Table, printNamespace bool, eventType watch.EventType) (tea.Cmd, error) {
+func (p *Printer) addObjectToTable(objTable *metav1.Table, eventType watch.EventType) (tea.Cmd, error) {
 	var cmd tea.Cmd
 	for _, row := range objTable.Rows {
 		unstrucObj, ok := row.Object.Object.(*unstructured.Unstructured)
@@ -380,7 +392,7 @@ func (p *Printer) addObjectToTable(objTable *metav1.Table, printNamespace bool, 
 			Fields:    make([]any, 0, len(p.colDefs)),
 			SortField: name,
 		}
-		if printNamespace {
+		if p.printNamespace {
 			namespace := metadata["namespace"]
 			tableRow.Fields = append(tableRow.Fields, namespace)
 			tableRow.SortField = fmt.Sprintf("%s/%s", namespace, name)
@@ -393,41 +405,7 @@ func (p *Printer) addObjectToTable(objTable *metav1.Table, printNamespace bool, 
 			if colDef.Priority != 0 && !p.WideOutput {
 				continue
 			}
-			cellStr := fmt.Sprint(cell)
-			switch strings.ToLower(colDef.Name) {
-			case "age", "created at":
-				tableRow.Fields = append(tableRow.Fields, creationTime)
-			case "status":
-				if eventType == watch.Deleted {
-					cell = "Deleted"
-				} else {
-					style := ParseStatusStyle(cellStr)
-					cell = table.StyledColumn{
-						Value: cell,
-						Style: style,
-					}
-				}
-				tableRow.Fields = append(tableRow.Fields, cell)
-			case "restarts":
-				if eventType != watch.Deleted && cellStr != "0" {
-					cell = table.StyledColumn{
-						Value: cell,
-						Style: StyleFractionWarning,
-					}
-				}
-				tableRow.Fields = append(tableRow.Fields, cell)
-			default:
-				if eventType != watch.Deleted {
-					fractionStyle, ok := ParseFractionStyle(cellStr)
-					if ok {
-						cell = table.StyledColumn{
-							Value: cell,
-							Style: fractionStyle,
-						}
-					}
-				}
-				tableRow.Fields = append(tableRow.Fields, cell)
-			}
+			tableRow.Fields = append(tableRow.Fields, p.parseCell(cell, eventType, colDef, creationTime))
 		}
 		switch eventType {
 		case watch.Error:
@@ -441,6 +419,61 @@ func (p *Printer) addObjectToTable(objTable *metav1.Table, printNamespace bool, 
 		cmd = p.Table.AddRow(tableRow)
 	}
 	return cmd, nil
+}
+
+func (p *Printer) parseCell(cell any, eventType watch.EventType, colDef metav1.TableColumnDefinition, creationTime time.Time) any {
+	cellStr := fmt.Sprint(cell)
+	columnNameLower := strings.ToLower(colDef.Name)
+	switch {
+	case columnNameLower == "age",
+		// some non-namespaced resources (e.g Role) gives timestamp instead of age
+		columnNameLower == "created at":
+		return creationTime
+	case columnNameLower == "status":
+		if eventType == watch.Deleted {
+			cell = "Deleted"
+		} else {
+			style := ParseStatusStyle(cellStr)
+			cell = table.StyledColumn{
+				Value: cell,
+				Style: style,
+			}
+		}
+		return cell
+	case p.apiVersion == "v1" && p.kind == "Pod" && columnNameLower == "restarts":
+		// 0, the most common case
+		if cellStr == "0" {
+			return cell
+		}
+		count, dur, ok := parsePodRestarts(cellStr)
+		if ok {
+			cell = table.CountAgeColumn{
+				Count: count,
+				Time:  time.Now().Add(-dur),
+			}
+		}
+		// Only add styling if not deleted, to not add excess coloring
+		if eventType != watch.Deleted {
+			cell = table.StyledColumn{
+				Value: cell,
+				Style: StyleFractionWarning,
+			}
+		}
+		return cell
+	// Only parse fraction (e.g "1/2") if the resources was not deleted,
+	// so we don't have colored fraction on a grayed-out row.
+	case eventType != watch.Deleted:
+		fractionStyle, ok := ParseFractionStyle(cellStr)
+		if ok {
+			cell = table.StyledColumn{
+				Value: cell,
+				Style: fractionStyle,
+			}
+		}
+		return cell
+	default:
+		return cell
+	}
 }
 
 func transformRequests(req *rest.Request) {

--- a/pkg/klock/klock.go
+++ b/pkg/klock/klock.go
@@ -431,7 +431,10 @@ func (p *Printer) parseCell(cell any, eventType watch.EventType, colDef metav1.T
 		return creationTime
 	case columnNameLower == "status":
 		if eventType == watch.Deleted {
-			cell = "Deleted"
+			cell = table.AgoColumn{
+				Value: "Deleted",
+				Time:  time.Now(),
+			}
 		} else {
 			style := ParseStatusStyle(cellStr)
 			cell = table.StyledColumn{
@@ -445,10 +448,10 @@ func (p *Printer) parseCell(cell any, eventType watch.EventType, colDef metav1.T
 		if cellStr == "0" {
 			return cell
 		}
-		count, dur, ok := parsePodRestarts(cellStr)
+		countStr, dur, ok := parsePodRestarts(cellStr)
 		if ok {
-			cell = table.CountAgeColumn{
-				Count: count,
+			cell = table.AgoColumn{
+				Value: countStr,
 				Time:  time.Now().Add(-dur),
 			}
 		}

--- a/pkg/klock/parsing.go
+++ b/pkg/klock/parsing.go
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: 2023 Kalle Fagerberg
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package klock
+
+import (
+	"fmt"
+	"io"
+	"regexp"
+	"strconv"
+	"time"
+)
+
+var podRestartsRegex = regexp.MustCompile(`^(\d+)(?: \((\S+) ago\))$`)
+
+func parsePodRestarts(s string) (int, time.Duration, bool) {
+	// 0, the most common case
+	if s == "0" {
+		return 0, 0, false
+	}
+	groups := podRestartsRegex.FindStringSubmatch(s)
+	if groups == nil {
+		// No match
+		return 0, 0, false
+	}
+	groupCount := groups[1]
+	groupDur := groups[2]
+	dur, ok := parseHumanDuration(groupDur)
+	if !ok {
+		return 0, 0, false
+	}
+	count, err := strconv.Atoi(groupCount)
+	if err != nil {
+		return 0, 0, false
+	}
+	return count, dur, true
+}
+
+func parseHumanDuration(s string) (time.Duration, bool) {
+	const (
+		DAY = time.Hour * 24
+		// This is how [k8s.io/apimachinery/pkg/util/duration] defines a year
+		YEAR = DAY * 365
+	)
+
+	rest := s
+	var dur time.Duration
+
+	for rest != "" {
+		num, char, newRest, ok := parseHumanDurationSegment(rest)
+		if !ok {
+			return dur, false
+		}
+		rest = newRest
+		switch char {
+		case 'y':
+			dur += time.Duration(num) * YEAR
+		case 'd':
+			dur += time.Duration(num) * DAY
+		case 'h':
+			dur += time.Duration(num) * time.Hour
+		case 'm':
+			dur += time.Duration(num) * time.Minute
+		case 's':
+			dur += time.Duration(num) * time.Second
+		default:
+			return dur, false
+		}
+	}
+	return dur, true
+}
+
+func parseHumanDurationSegment(s string) (num int, char rune, rest string, ok bool) {
+	n, err := fmt.Sscanf(s, "%d%c%s", &num, &char, &rest)
+	ok = (err == io.EOF && n == 2) || err == nil
+	return
+}

--- a/pkg/klock/parsing.go
+++ b/pkg/klock/parsing.go
@@ -21,33 +21,28 @@ import (
 	"fmt"
 	"io"
 	"regexp"
-	"strconv"
 	"time"
 )
 
 var podRestartsRegex = regexp.MustCompile(`^(\d+)(?: \((\S+) ago\))$`)
 
-func parsePodRestarts(s string) (int, time.Duration, bool) {
+func parsePodRestarts(s string) (string, time.Duration, bool) {
 	// 0, the most common case
 	if s == "0" {
-		return 0, 0, false
+		return s, 0, false
 	}
 	groups := podRestartsRegex.FindStringSubmatch(s)
 	if groups == nil {
 		// No match
-		return 0, 0, false
+		return s, 0, false
 	}
 	groupCount := groups[1]
 	groupDur := groups[2]
 	dur, ok := parseHumanDuration(groupDur)
 	if !ok {
-		return 0, 0, false
+		return s, 0, false
 	}
-	count, err := strconv.Atoi(groupCount)
-	if err != nil {
-		return 0, 0, false
-	}
-	return count, dur, true
+	return groupCount, dur, true
 }
 
 func parseHumanDuration(s string) (time.Duration, bool) {

--- a/pkg/klock/parsing_test.go
+++ b/pkg/klock/parsing_test.go
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: 2023 Kalle Fagerberg
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the
+// Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package klock
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseHumanDurationSegment(t *testing.T) {
+	tests := []struct {
+		input string
+		num   int
+		char  rune
+		rest  string
+		ok    bool
+	}{
+		{
+			input: "12y",
+			num:   12,
+			char:  'y',
+			rest:  "",
+			ok:    true,
+		},
+		{
+			input: "12y15d",
+			num:   12,
+			char:  'y',
+			rest:  "15d",
+			ok:    true,
+		},
+		{
+			input: "invalid",
+			ok:    false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			num, char, rest, ok := parseHumanDurationSegment(tc.input)
+			if tc.ok != ok {
+				t.Fatalf("want ok=%t, got ok=%t & num=%d & char=%c & rest=%s", tc.ok, ok, num, char, rest)
+			}
+			if !tc.ok {
+				return
+			}
+			if tc.num != num {
+				t.Errorf("want num=%d, got num=%d", tc.num, num)
+			}
+			if tc.char != char {
+				t.Errorf("want char=%c, got char=%c", tc.char, char)
+			}
+			if tc.rest != rest {
+				t.Errorf("want rest=%s, got rest=%s", tc.rest, rest)
+			}
+		})
+	}
+}
+
+func TestParseHumanDuration(t *testing.T) {
+	const (
+		DAY = time.Hour * 24
+		// This is how [k8s.io/apimachinery/pkg/util/duration] defines a year
+		YEAR = DAY * 365
+	)
+
+	tests := []struct {
+		input string
+		dur   time.Duration
+		ok    bool
+	}{
+		{
+			input: "1d",
+			dur:   DAY,
+			ok:    true,
+		},
+		{
+			input: "1d15m",
+			dur:   DAY + 15*time.Minute,
+			ok:    true,
+		},
+		{
+			input: "1d15m30s",
+			dur:   DAY + 15*time.Minute + 30*time.Second,
+			ok:    true,
+		},
+		{
+			input: "1y30d",
+			dur:   YEAR + 30*DAY,
+			ok:    true,
+		},
+		{
+			input: "1f",
+			ok:    false,
+		},
+		{
+			input: "1h30p",
+			ok:    false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			dur, ok := parseHumanDuration(tc.input)
+			if tc.ok != ok {
+				t.Fatalf("want ok=%t, got ok=%t & dur=%s", tc.ok, ok, dur)
+			}
+			if !tc.ok {
+				return
+			}
+			if tc.dur != dur {
+				t.Errorf("want dur=%s, got dur=%s", tc.dur, dur)
+			}
+		})
+	}
+}

--- a/pkg/table/row.go
+++ b/pkg/table/row.go
@@ -42,14 +42,14 @@ type StyledColumn struct {
 	Style lipgloss.Style
 }
 
-type CountAgeColumn struct {
-	Count int
+type AgoColumn struct {
+	Value string
 	Time  time.Time
 }
 
-func (c CountAgeColumn) String() string {
+func (c AgoColumn) String() string {
 	dur := time.Since(c.Time)
-	return fmt.Sprintf("%d (%s ago)", c.Count, duration.HumanDuration(dur))
+	return fmt.Sprintf("%s (%s ago)", c.Value, duration.HumanDuration(dur))
 }
 
 type Row struct {

--- a/pkg/table/row.go
+++ b/pkg/table/row.go
@@ -42,6 +42,16 @@ type StyledColumn struct {
 	Style lipgloss.Style
 }
 
+type CountAgeColumn struct {
+	Count int
+	Time  time.Time
+}
+
+func (c CountAgeColumn) String() string {
+	dur := time.Since(c.Time)
+	return fmt.Sprintf("%d (%s ago)", c.Count, duration.HumanDuration(dur))
+}
+
 type Row struct {
 	ID        string
 	Fields    []any
@@ -98,6 +108,8 @@ func renderColumn(value any) string {
 	case time.Time:
 		dur := time.Since(value)
 		return duration.HumanDuration(dur)
+	case fmt.Stringer:
+		return value.String()
 	default:
 		if value == nil {
 			return ""


### PR DESCRIPTION
- Added parsing of `1h ago` on pod's RESTARTS column
- Added `1h ago` to pod's STATUS column when a pod is deleted
- Added workflow to run tests

Closes #37
