### PR TITLE
Fixed --watch-kubeconfig glitches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 - Added Snap: `sudo snap install klock --edge` (#43)
 
+- Fixed glitches when using flag `--watch-kubeconfig` / `-W`.
+  The watch was not properly restarting, but works great now. (#57)
+
 ## v0.4.0 (2023-09-03)
 
 - Added text filtering. (#32, thanks @semihbkgr!)

--- a/pkg/klock/klock.go
+++ b/pkg/klock/klock.go
@@ -145,7 +145,8 @@ type Watcher struct {
 	Printer Printer
 	Args    []string
 
-	errorChan chan error
+	printNamespace bool
+	errorChan      chan error
 }
 
 func (w *Watcher) ErrorChan() <-chan error {


### PR DESCRIPTION
The watch loop logic was a bit convoluted before. It also had the "wait 5 seconds" part in 2 places.

The glitch came from that the `Watcher.Watch` wasen't syncronous, while the caller used it as if it was. It ran `Watcher.startWatch` in a new goroutine. This also lead to the initial watch to keep restarting every 5 seconds before, just because it was told to cancel.

Fixed the semantic so that watch = syncronous, and thanks to some refactoring the glitch is gone.

Verified by extensive testing and debugging.

Closes #17
