### PR TITLE
Show spinner on restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   The fix is just adding a small 150ms sleep, which is hopefully enough time
   for tools like `kubectx` to finish writing the kubeconfig file. (#63)
 
+- Added spinner when the watch restarts (either from `--watch-kubeconfig` or
+  from an error), to indicate that it's loading. (#64)
+
 ## v0.5.0 (2023-11-04)
 
 - BREAKING: Changed binary name from `klock` to `kubectl-klock`.

--- a/pkg/klock/klock.go
+++ b/pkg/klock/klock.go
@@ -171,9 +171,17 @@ func (w *Watcher) WatchLoop(ctx context.Context, restartChan <-chan struct{}) er
 		clearBeforePrinting = true
 		select {
 		case err := <-watchErrChan:
+			if cmd := w.Printer.Table.StartSpinner(); cmd != nil {
+				w.Program.Send(cmd())
+			}
 			w.errorChan <- fmt.Errorf("restart in 5s: %w", err)
 			time.Sleep(5 * time.Second)
+			w.Printer.Table.StopSpinner()
+			w.Printer.Table.SetError(nil)
 		case <-restartChan:
+			if cmd := w.Printer.Table.StartSpinner(); cmd != nil {
+				w.Program.Send(cmd())
+			}
 			// Prevent it from restarting too eagerly when we're told to restart
 			// so the filesystem has time to flush, such as in case of
 			// "kubectx" on bigger kubeconfigs.


### PR DESCRIPTION
Enables the spinner when it restarts, which helps show that the watch is loading the new data after a kubeconfig refresh or after an erro
