### PR TITLE
Update to Go 1.22.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/applejag/kubectl-klock
 
-go 1.22.2
+go 1.22.3
 
 require (
 	github.com/charmbracelet/bubbles v0.18.0


### PR DESCRIPTION
Resolves govulncheck:

```console
$ govulncheck ./...
Scanning your code and 776 packages across 94 dependent modules for known vulnerabilities...

=== Symbol Results ===

Vulnerability #1: GO-2024-2824
    Malformed DNS message can cause infinite loop in net
  More info: https://pkg.go.dev/vuln/GO-2024-2824
  Standard library
    Found in: net@go1.22.2
    Fixed in: net@go1.22.3
    Example traces found:
      #1: pkg/klock/klock.go:297:23: klock.Watcher.pipeEvents calls resource.Result.Watch, which eventually calls net.Dialer.DialContext

Your code is affected by 1 vulnerability from the Go standard library.
This scan found no other vulnerabilities in packages you import or modules you
require.
Use '-show verbose' for more details.
```
