### PR TITLE
Fix ANSI coloring issue

### DIFF
--- a/pkg/klock/klock.go
+++ b/pkg/klock/klock.go
@@ -257,10 +257,10 @@ func (w *Watcher) watch(ctx context.Context, clearBeforePrinting bool) error {
 	r := resource.NewBuilder(w.ConfigFlags).
 		Unstructured().
 		NamespaceParam(ns).DefaultNamespace().AllNamespaces(w.AllNamespaces).
-		//FilenameParam(o.ExplicitNamespace, &o.FilenameOptions).
+		// FilenameParam(o.ExplicitNamespace, &o.FilenameOptions).
 		LabelSelectorParam(w.LabelSelector).
 		FieldSelectorParam(w.FieldSelector).
-		//RequestChunksOf(o.ChunkSize).
+		// RequestChunksOf(o.ChunkSize).
 		ResourceTypeOrNameArgs(true, w.Args...).
 		SingleResourceType().
 		Latest().
@@ -620,9 +620,9 @@ func kubecolorColorToLipgloss(c kubecolor.Color) lipgloss.Style {
 		case color.Color:
 			switch {
 			case col.IsFg():
-				style = style.Foreground(lipgloss.Color("#" + col.RGB().Hex()))
+				style = style.Foreground(lipgloss.ANSIColor(uint(col) - uint(color.FgBase)))
 			case col.IsBg():
-				style = style.Background(lipgloss.Color("#" + col.RGB().Hex()))
+				style = style.Background(lipgloss.ANSIColor(uint(col) - uint(color.BgBase)))
 			case col.IsOption():
 				switch col {
 				case color.OpBold:


### PR DESCRIPTION
Fixes where kubectl-klock would force convert kubecolor's color config to what it thought the RGB representation was.

This means kubectl-klock would not use the ANSI color codes.

When a user has ANSI 4-bit color codes configured in their kubecolor config, then it should use colors from their terminal emulator's theme settings.

Before:

![image](https://github.com/user-attachments/assets/8cecb03b-c2cf-45f0-80b7-1240badec8c5)

After:

![image](https://github.com/user-attachments/assets/bcf499fa-f70f-4947-b958-5a3940e86e11)

So that now it matches kubecolor:

![image](https://github.com/user-attachments/assets/202eef33-099c-4c65-b962-a913f096f42d)



Fixes #158
