### PR TITLE
bugfix: Fix panic that sometimes happen with lots of resources

### DIFF
--- a/pkg/klock/klock.go
+++ b/pkg/klock/klock.go
@@ -468,9 +468,9 @@ func (p *Printer) addObjectToTable(objTable *metav1.Table, eventType watch.Event
 			}
 			tableRow.Fields = append(tableRow.Fields, p.parseCell(cell, row, eventType, unstrucObj.Object, colDef, creationTime))
 		}
+		objLabels := unstrucObj.GetLabels()
 		for _, label := range p.LabelCols {
-			labelValue := unstrucObj.GetLabels()[label]
-			tableRow.Fields = append(tableRow.Fields, labelValue)
+			tableRow.Fields = append(tableRow.Fields, objLabels[label])
 		}
 		switch eventType {
 		case watch.Error:
@@ -479,7 +479,7 @@ func (p *Printer) addObjectToTable(objTable *metav1.Table, eventType watch.Event
 			tableRow.MarkDeleted()
 		}
 		// it's fine to only use the latest returned cmd, because of how
-		// [table.AddRow] is implemented
+		// [table.Model.AddRow] is implemented
 
 		cmd = p.Table.AddRow(tableRow)
 	}

--- a/pkg/table/row.go
+++ b/pkg/table/row.go
@@ -105,7 +105,10 @@ func (r *Row) RenderedFields() []string {
 }
 
 func (r *Row) ReRenderFields() {
-	r.renderedFields = resizeSlice(r.renderedFields, len(r.Fields))
+	// Store result in an temporary variable, to avoid possibility of another
+	// goroutine changing the slice size beneath our feet while we update it
+	// See: https://github.com/applejag/kubectl-klock/issues/161
+	rendered := resizeSlice(r.renderedFields, len(r.Fields))
 	offset := 0
 	if r.HasLeadingNamespaceColumn {
 		offset = -1
@@ -115,8 +118,9 @@ func (r *Row) ReRenderFields() {
 		cfg = nil
 	}
 	for i, col := range r.Fields {
-		r.renderedFields[i] = renderColumn(col, i+offset, cfg)
+		rendered[i] = renderColumn(col, i+offset, cfg)
 	}
+	r.renderedFields = rendered
 }
 
 func (r *Row) MarkDeleted() {


### PR DESCRIPTION
This is a weird patch for a weird bug.

It basically boils down to "multi-threaded code is hard"

I wrote a small summary of what I believe is happening in the issue: https://github.com/applejag/kubectl-klock/issues/161#issuecomment-2967300658

Closes #161
