### PR TITLE
Color all cells with status coloring

### DIFF
--- a/pkg/klock/color.go
+++ b/pkg/klock/color.go
@@ -38,6 +38,10 @@ var (
 	StyleStatusOK      = lipgloss.NewStyle().Foreground(lipgloss.ANSIColor(2))
 	StyleStatusError   = lipgloss.NewStyle().Foreground(lipgloss.ANSIColor(1))
 	StyleStatusWarning = lipgloss.NewStyle().Foreground(lipgloss.ANSIColor(3))
+
+	StyleStatusNull  = lipgloss.NewStyle().Foreground(lipgloss.ANSIColor(8))
+	StyleStatusTrue  = lipgloss.NewStyle().Foreground(lipgloss.ANSIColor(2))
+	StyleStatusFalse = lipgloss.NewStyle().Foreground(lipgloss.ANSIColor(3))
 )
 
 func FractionStyle(str string) (lipgloss.Style, bool) {
@@ -99,6 +103,7 @@ func StatusStyle(status string) lipgloss.Style {
 		"ContainerGCFailed",
 		"ImageGCFailed",
 		"FailedNodeAllocatableEnforcement",
+		"FailedCreate",
 		"FailedCreatePodSandBox",
 		"FailedPodSandBoxStatus",
 		"FailedMountOnFilesystemMismatch",
@@ -112,6 +117,9 @@ func StatusStyle(status string) lipgloss.Style {
 		// Config event reason list
 		"FailedValidation",
 		// Lifecycle hooks
+		"PreCreateHookError",
+		"PreStartHookError",
+		"PostStartHookError",
 		"FailedPostStartHook",
 		"FailedPreStopHook",
 		// Node status list
@@ -119,15 +127,20 @@ func StatusStyle(status string) lipgloss.Style {
 		"NetworkUnavailable",
 
 		// some other status
-		"CreateContainerConfigError",
 		"ContainerStatusUnknown",
+		"CreateContainerConfigError",
+		"CreateContainerError",
+		"ContainerCannotRun",
 		"CrashLoopBackOff",
+		"DeadlineExceeded",
 		"ImagePullBackOff",
 		"Evicted",
 		"FailedScheduling",
 		"Error",
 		"ErrImagePull",
-
+		"OOMKilled",
+		"RunContainerError",
+		"StartError",
 		// PVC status
 		"Lost":
 		return StyleStatusError
@@ -147,23 +160,20 @@ func StatusStyle(status string) lipgloss.Style {
 		"SuccessfulAttachVolume",
 		"SuccessfulMountVolume",
 		"NodeAllocatableEnforced",
+		"SchedulingDisabled",
 		// Image manager event reason list
 		// Probe event reason list
 		"ProbeWarning",
 		// Pod worker event reason list
 		// Config event reason list
 		// Lifecycle hooks
-		// Node event reason list
-		"SchedulingDisabled",
-		"DiskPressure",
-		"MemoryPressure",
-		"PIDPressure",
 
 		// some other status
 		"Pending",
 		"ContainerCreating",
 		"PodInitializing",
 		"Terminating",
+		"Terminated",
 		"Warning",
 
 		// PV reclaim policy
@@ -171,7 +181,9 @@ func StatusStyle(status string) lipgloss.Style {
 
 		// PVC status
 		"Available",
-		"Released":
+		"Released",
+
+		"ScalingReplicaSet":
 		return StyleStatusWarning
 	case
 		"Running",
@@ -185,6 +197,8 @@ func StatusStyle(status string) lipgloss.Style {
 		"VolumeResizeSuccessful",
 		"FileSystemResizeSuccessful",
 		"Ready",
+		"Scheduled",
+		"SuccessfulCreate",
 
 		// PV reclaim policy
 		"Retain",
@@ -192,6 +206,14 @@ func StatusStyle(status string) lipgloss.Style {
 		// PVC status
 		"Bound":
 		return StyleStatusOK
+
+	// Also allow some data-related values, common in CRD statuses (e.g. READY column with True/False)
+	case "null", "<none>", "<unknown>", "<unset>", "<nil>", "<invalid>":
+		return StyleStatusNull
+	case "true", "True", "TRUE":
+		return StyleStatusTrue
+	case "false", "False", "FALSE":
+		return StyleStatusFalse
 	}
 	// some ok status, not colored:
 	// "SandboxChanged",

--- a/pkg/klock/klock.go
+++ b/pkg/klock/klock.go
@@ -127,6 +127,10 @@ func Execute(o Options, args []string) error {
 		overrideLipglossWithKubecolor(&StyleStatusOK, o.Kubecolor.Theme.Status.Success)
 		overrideLipglossWithKubecolor(&StyleStatusError, o.Kubecolor.Theme.Status.Error)
 		overrideLipglossWithKubecolor(&StyleStatusWarning, o.Kubecolor.Theme.Status.Warning)
+
+		overrideLipglossWithKubecolor(&StyleStatusNull, o.Kubecolor.Theme.Data.Null)
+		overrideLipglossWithKubecolor(&StyleStatusTrue, o.Kubecolor.Theme.Data.True)
+		overrideLipglossWithKubecolor(&StyleStatusFalse, o.Kubecolor.Theme.Data.False)
 	}
 
 	printer := Printer{
@@ -509,14 +513,6 @@ func (p *Printer) parseCell(cell any, row metav1.TableRow, eventType watch.Event
 		// some non-namespaced resources (e.g Role) gives timestamp instead of age
 		columnNameLower == "created at":
 		return creationTime
-	case columnNameLower == "status":
-		if eventType == watch.Deleted {
-			return table.AgoColumn{
-				Value: "Deleted",
-				Time:  time.Now(),
-			}
-		}
-		return StatusColumn(cellStr)
 	case p.apiVersion == "v1" && p.kind == "Event" && columnNameLower == "last seen",
 		p.apiVersion == "batch/v1" && p.kind == "CronJob" && columnNameLower == "last schedule":
 
@@ -552,8 +548,6 @@ func (p *Printer) parseCell(cell any, row metav1.TableRow, eventType watch.Event
 			return cell
 		}
 		return time.Now().Add(-dur)
-	case p.apiVersion == "v1" && p.kind == "Event" && columnNameLower == "reason":
-		return StatusColumn(cellStr)
 	case p.apiVersion == "v1" && p.kind == "Pod" && columnNameLower == "restarts":
 		// 0, the most common case
 		if cellStr == "0" {
@@ -574,13 +568,13 @@ func (p *Printer) parseCell(cell any, row metav1.TableRow, eventType watch.Event
 			}
 		}
 		return cell
-	case p.apiVersion == "storage.k8s.io/v1" && p.kind == "StorageClass" && columnNameLower == "reclaimpolicy":
-		return StatusColumn(cellStr)
-	case p.apiVersion == "v1" && p.kind == "PersistentVolume" && columnNameLower == "reclaim policy":
-		return StatusColumn(cellStr)
-	case p.apiVersion == "v1" && p.kind == "PersistentVolume" && columnNameLower == "status":
-		return StatusColumn(cellStr)
-	case p.apiVersion == "v1" && p.kind == "PersistentVolumeClaim" && columnNameLower == "status":
+	case columnNameLower == "status":
+		if eventType == watch.Deleted {
+			return table.AgoColumn{
+				Value: "Deleted",
+				Time:  time.Now(),
+			}
+		}
 		return StatusColumn(cellStr)
 	// Only parse fraction (e.g "1/2") if the resources was not deleted,
 	// so we don't have colored fraction on a grayed-out row.
@@ -592,9 +586,9 @@ func (p *Printer) parseCell(cell any, row metav1.TableRow, eventType watch.Event
 				Style: fractionStyle,
 			}
 		}
-		return cell
+		return StatusColumn(cellStr)
 	default:
-		return cell
+		return cellStr
 	}
 }
 


### PR DESCRIPTION
Looks for the "Ready" keywords in all columns instead of only column called `STATUS`

Also adds the `True`/`False`/`<none>` keyword colors introduced in https://github.com/kubecolor/kubecolor/pull/307

Before:

<img width="807" height="121" alt="image" src="https://github.com/user-attachments/assets/570ff5fa-f3d7-4d50-9613-997ba2412430" />

<img width="499" height="95" alt="image" src="https://github.com/user-attachments/assets/9b3423b9-630d-4540-b725-bcd164bb3189" />


After:

<img width="788" height="120" alt="image" src="https://github.com/user-attachments/assets/84aec873-5d89-4cce-8b2a-fd3af766e8e6" />

<img width="511" height="73" alt="image" src="https://github.com/user-attachments/assets/1ed50759-1847-4578-b90c-fac1b4c20e95" />


Closes #216
